### PR TITLE
1.1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Nooky's SWAG Custom Presets
-![Version: 1.1.9](https://img.shields.io/badge/Version-1.1.9-informational?style=flat-square)
+![Version: 1.1.10](https://img.shields.io/badge/Version-1.1.10-informational?style=flat-square)
 
 **SWAG 1.4.3 by props IS REQUIRED!**
 
@@ -30,10 +30,6 @@ Be sure you have SWAG 1.4.2 installed first!
 2. download the .zip, extract/copy/paste and overwrite into your SWAG folder: `user/mods/SWAG/`
 
 3. play the game
-
-**IMPORTANT: SWAG patterns may not load properly until your 2nd raid!**
-
-If you're experiencing weird spawns in your 1st raid after loading up the game, quit (SVM safe exit is a nice option) and re-load into your 2nd raid and you should be good to go.
 
 ## How to Uninstall
 
@@ -110,7 +106,7 @@ Yes - feel free to tune any of these to your liking - my default caps are just m
         "reserve": 24,
         "interchange": 24,
         "laboratory": 20,
-        "tarkovstreets": 22
+        "tarkovstreets": 24
 	}
 ```
 

--- a/config/config.json
+++ b/config/config.json
@@ -30,7 +30,7 @@
 	"UseDefaultSpawns": {
 		"Waves": false,
 		"Bosses": false,
-		"TriggeredWaves": true
+		"TriggeredWaves": false
 	},
 	"DebugOutput": false
 }

--- a/src/SWAG.ts
+++ b/src/SWAG.ts
@@ -15,6 +15,7 @@ import { StaticRouterModService } from "@spt-aki/services/mod/staticRouter/Stati
 import { JsonUtil } from "@spt-aki/utils/JsonUtil";
 import { RandomUtil } from "@spt-aki/utils/RandomUtil";
 import { DependencyContainer } from "tsyringe";
+import { LocationCallbacks } from "@spt-aki/callbacks/LocationCallbacks";
 import * as ClassDef from "./ClassDef";
 import {
   BossPattern,
@@ -32,6 +33,7 @@ import { spawn } from "child_process";
 
 const modName = "SWAG";
 let logger: ILogger;
+let LocationCallbacks; LocationCallbacks;
 let jsonUtil: JsonUtil;
 let configServer: ConfigServer;
 let botConfig: IBotConfig;
@@ -137,7 +139,7 @@ class SWAG implements IPreAkiLoadMod, IPostDBLoadMod {
           ): any => {
             SWAG.ClearDefaultSpawns();
             SWAG.ConfigureMaps();
-            return output;
+            return LocationCallbacks.getLocationData(url, info, sessionID);
           },
         },
       ],
@@ -147,6 +149,7 @@ class SWAG implements IPreAkiLoadMod, IPostDBLoadMod {
 
   postDBLoad(container: DependencyContainer): void {
     logger = container.resolve<ILogger>("WinstonLogger");
+    LocationCallbacks = container.resolve<LocationCallbacks>("LocationCallbacks");
     jsonUtil = container.resolve<JsonUtil>("JsonUtil");
     configServer = container.resolve<ConfigServer>("ConfigServer");
     botConfig = configServer.getConfig<IBotConfig>(ConfigTypes.BOT);


### PR DESCRIPTION
Major Fixes

FIXED: 1st Raid "Bug"
1st raid bug is GONE! All patterns will now load properly when you start your game, no need to quit/restart/etc.

Special thanks to Props and DrakiaXYZ for debugging and finding the fix!

FIXED: Disabled "triggered waves"
I've had triggered waves left on which has introduced unexpected boss spawns in some raids (this is my fault, sorry!) - this is now set to "false" as originally intended so that all bosses spawn as expected going forward (seriously this time)