### PR TITLE
1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Nooky's SWAG Custom Presets
-![Version: 1.1.11](https://img.shields.io/badge/Version-1.1.11-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square)
 
 **SWAG 1.4.3+ by props IS REQUIRED!**
 

--- a/config/config.json
+++ b/config/config.json
@@ -9,24 +9,35 @@
     "WaveTimerMinSec": 60,
     "WaveTimerMaxSec": 120
   },
-	"BossChance": 20,
+	"BossChance": {
+    "gluhar": 20,
+    "killa": 20,
+    "tagilla": 20,
+    "zryachiy": 100,
+    "sanitar": 20,
+    "reshala": 20,
+    "shturman": 20,
+    "goons": 20
+  },
+  "RogueChance": 80,
+  "RaiderChance": 80,
 	"SniperChance": 50,
 	"pmcWaves": true,
-	"pmcSpawnWeight": 25,
-	"scavSpawnWeight": 75,
+	"pmcSpawnWeight": 20,
+	"scavSpawnWeight": 80,
   "ScavInLabs": false,
 	"MaxBotCap": {
 		"factory": 14,
-		"customs": 24,
-		"woods": 26,
+		"customs": 25,
+		"woods": 27,
 		"shoreline": 28,
 		"lighthouse": 30,
 		"reserve": 24,
 		"interchange": 24,
 		"laboratory": 14,
-		"tarkovstreets": 24
+		"tarkovstreets": 25
 	},
-	"MaxBotPerZone": 6,
+	"MaxBotPerZone": 8,
 	"UseDefaultSpawns": {
 		"Waves": false,
 		"Bosses": false,

--- a/config/patterns/all_scav.json
+++ b/config/patterns/all_scav.json
@@ -11,19 +11,7 @@
           },
           {
             "BotType": "assault",
-            "MaxBotCount": 2
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 2
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 2
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 2
+            "MaxBotCount": 3
           },
           {
             "BotType": "assault",
@@ -59,11 +47,23 @@
           },
           {
             "BotType": "assault",
+            "MaxBotCount": 3
+          },
+          {
+            "BotType": "assault",
             "MaxBotCount": 2
           },
           {
             "BotType": "assault",
             "MaxBotCount": 2
+          },
+          {
+            "BotType": "assault",
+            "MaxBotCount": 2
+          },
+          {
+            "BotType": "assault",
+            "MaxBotCount": 3
           },
           {
             "BotType": "assault",

--- a/config/patterns/customs_pmc.json
+++ b/config/patterns/customs_pmc.json
@@ -10,8 +10,8 @@
             "MaxBotCount": 2
           }
         ],
-        "Time_min": 600,
-        "Time_max": 1800,
+        "Time_min": 500,
+        "Time_max": 1900,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": false,
         "BotZone": [
@@ -20,8 +20,6 @@
           "ZoneBrige",
           "ZoneTankSquare",
           "ZoneCrossRoad",
-          "ZoneDormitory",
-          "ZoneCustoms",
           "ZoneFactorySide",
           "ZoneFactoryCenter",
           "ZoneOldAZS"
@@ -32,14 +30,28 @@
         "Bots": [
           {
             "BotType": "pmc",
-            "MaxBotCount": 3
+            "MaxBotCount": 2
           }
         ],
-        "Time_min": 600,
-        "Time_max": 1200,
+        "Time_min": 300,
+        "Time_max": 900,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": false,
         "BotZone": ["ZoneDormitory"]
+      },
+      {
+        "Name": "PMCs at Customs",
+        "Bots": [
+          {
+            "BotType": "pmc",
+            "MaxBotCount": 2
+          }
+        ],
+        "Time_min": 300,
+        "Time_max": 900,
+        "RandomTimeSpawn": false,
+        "OnlySpawnOnce": false,
+        "BotZone": ["ZoneCustoms"]
       }
     ],
     "MapBosses": [

--- a/config/patterns/customs_scav.json
+++ b/config/patterns/customs_scav.json
@@ -8,42 +8,12 @@
           {
             "BotType": "assault",
             "MaxBotCount": 3
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 2
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 3
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 2
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 3
           }
         ],
-        "Time_min": 45,
-        "Time_max": 90,
+        "Time_min": 30,
+        "Time_max": 45,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": true,
-        "BotZone": null
-      },
-      {
-        "Name": "assaults",
-        "Bots": [
-          {
-            "BotType": "assault",
-            "MaxBotCount": 3
-          }
-        ],
-        "Time_min": 500,
-        "Time_max": 1200,
-        "RandomTimeSpawn": false,
-        "OnlySpawnOnce": false,
         "BotZone": [
           "ZoneScavBase",
           "ZoneBlockPost",
@@ -58,6 +28,27 @@
         ]
       },
       {
+        "Name": "assaults",
+        "Bots": [
+          {
+            "BotType": "assault",
+            "MaxBotCount": 3
+          }
+        ],
+        "Time_min": 400,
+        "Time_max": 1000,
+        "RandomTimeSpawn": false,
+        "OnlySpawnOnce": false,
+        "BotZone": [
+          "ZoneScavBase",
+          "ZoneBlockPost",
+          "ZoneBrige",
+          "ZoneTankSquare",
+          "ZoneCrossRoad",
+          "ZoneOldAZS"
+        ]
+      },
+      {
         "Name": "SCAVs at Dorms",
         "Bots": [
           {
@@ -65,8 +56,8 @@
             "MaxBotCount": 3
           }
         ],
-        "Time_min": 600,
-        "Time_max": 1000,
+        "Time_min": 300,
+        "Time_max": 600,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": false,
         "BotZone": ["ZoneDormitory"]
@@ -76,11 +67,11 @@
         "Bots": [
           {
             "BotType": "assault",
-            "MaxBotCount": 2
+            "MaxBotCount": 3
           }
         ],
-        "Time_min": 400,
-        "Time_max": 1000,
+        "Time_min": 300,
+        "Time_max": 700,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": false,
         "BotZone": [

--- a/config/patterns/factory_pmc.json
+++ b/config/patterns/factory_pmc.json
@@ -32,8 +32,8 @@
             "MaxBotCount": 2
           }
         ],
-        "Time_min": 400,
-        "Time_max": 1000,
+        "Time_min": 300,
+        "Time_max": 800,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": false,
         "BotZone": ["BotZone"]

--- a/config/patterns/factory_scav.json
+++ b/config/patterns/factory_scav.json
@@ -7,7 +7,7 @@
         "Bots": [
           {
             "BotType": "assault",
-            "MaxBotCount": 4
+            "MaxBotCount": 5
           }
         ],
         "Time_min": 15,
@@ -25,7 +25,7 @@
           }
         ],
         "Time_min": 120,
-        "Time_max": 500,
+        "Time_max": 400,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": false,
         "BotZone": ["BotZone"]

--- a/config/patterns/interchange_pmc.json
+++ b/config/patterns/interchange_pmc.json
@@ -11,7 +11,7 @@
           }
         ],
         "Time_min": 600,
-        "Time_max": 1800,
+        "Time_max": 2000,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": false,
         "BotZone": [
@@ -35,8 +35,8 @@
             "MaxBotCount": 2
           }
         ],
-        "Time_min": 600,
-        "Time_max": 1800,
+        "Time_min": 300,
+        "Time_max": 1200,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": false,
         "BotZone": [
@@ -111,7 +111,7 @@
         "Supports": null,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": true,
-        "BossZone": ["ZoneIDEAPark","ZoneOLIPark"]
+        "BossZone": ["ZoneIDEAPark"]
       },
       {
         "Name": "sptusec",
@@ -122,7 +122,7 @@
         "Supports": null,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": true,
-        "BossZone": ["ZoneIDEAPark","ZoneOLIPark"]
+        "BossZone": ["ZoneOLIPark"]
       },
       {
         "Name": "sptusec",

--- a/config/patterns/interchange_scav.json
+++ b/config/patterns/interchange_scav.json
@@ -8,42 +8,12 @@
           {
             "BotType": "assault",
             "MaxBotCount": 3
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 2
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 3
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 2
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 3
           }
         ],
-        "Time_min": 45,
-        "Time_max": 90,
+        "Time_min": 30,
+        "Time_max": 45,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": true,
-        "BotZone": null
-      },
-      {
-        "Name": "assaults",
-        "Bots": [
-          {
-            "BotType": "assault",
-            "MaxBotCount": 3
-          }
-        ],
-        "Time_min": 500,
-        "Time_max": 1620,
-        "RandomTimeSpawn": false,
-        "OnlySpawnOnce": false,
         "BotZone": [
           "ZoneGoshan",
           "ZoneRoad",
@@ -54,6 +24,47 @@
           "ZoneCenter",
           "ZonePowerStation",
           "ZoneCenterBot",
+          "ZoneTrucks"
+        ]
+      },
+      {
+        "Name": "assaults",
+        "Bots": [
+          {
+            "BotType": "assault",
+            "MaxBotCount": 3
+          }
+        ],
+        "Time_min": 220,
+        "Time_max": 700,
+        "RandomTimeSpawn": false,
+        "OnlySpawnOnce": false,
+        "BotZone": [
+          "ZoneGoshan",
+          "ZoneIDEA",
+          "ZoneOLI",
+          "ZoneCenter",
+          "ZoneCenterBot"
+        ]
+      },
+      {
+        "Name": "assaults",
+        "Bots": [
+          {
+            "BotType": "assault",
+            "MaxBotCount": 3
+          }
+        ],
+        "Time_min": 300,
+        "Time_max": 1100,
+        "RandomTimeSpawn": false,
+        "OnlySpawnOnce": false,
+        "BotZone": [
+          "ZoneRoad",
+          "ZoneOLIPark",
+          "ZoneIDEAPark",
+          "ZoneOLI",
+          "ZonePowerStation",
           "ZoneTrucks"
         ]
       }

--- a/config/patterns/labs_raiders.json
+++ b/config/patterns/labs_raiders.json
@@ -23,7 +23,6 @@
     ],
     "MapBosses": [
       {
-        "BossChance": 45,
         "BossEscortAmount": "1,1,1,1,2,2,2,1,1,1,1,2,2,2,3",
         "BossEscortType": "pmcbot",
         "BossName": "pmcbot",
@@ -33,7 +32,6 @@
         "Time": 900
       },
       {
-        "BossChance": 45,
         "BossEscortAmount": "1,1,1,1,2,2,2,1,1,1,1,2,2,2,3",
         "BossEscortType": "pmcbot",
         "BossName": "pmcbot",
@@ -43,7 +41,6 @@
         "Time": 300
       },
       {
-        "BossChance": 45,
         "BossEscortAmount": "1,1,1,1,2,2,2,1,1,1,1,2,2,2,3",
         "BossEscortType": "pmcbot",
         "BossName": "pmcbot",
@@ -55,7 +52,6 @@
         "TriggerName": "interactObject"
       },
       {
-        "BossChance": 45,
         "BossEscortAmount": "1,1,1,1,2,2,2,1,1,1,1,2,2,2,3",
         "BossEscortType": "pmcbot",
         "BossName": "pmcbot",
@@ -67,7 +63,6 @@
         "TriggerName": "interactObject"
       },
       {
-        "BossChance": 40,
         "BossEscortAmount": "1,1,1,1,2,2,2,1,1,1,1,2,2,2,3",
         "BossEscortType": "pmcbot",
         "BossName": "pmcbot",
@@ -79,7 +74,6 @@
         "TriggerName": "interactObject"
       },
       {
-        "BossChance": 45,
         "BossEscortAmount": "1,1,1,1,2,2,2,1,1,1,1,2,2,2,3",
         "BossEscortType": "pmcbot",
         "BossName": "pmcbot",
@@ -91,7 +85,6 @@
         "TriggerName": "interactObject"
       },
       {
-        "BossChance": 35,
         "BossEscortAmount": "1,1,1,1,2,2,2,1,1,1,1,2,2,2,3",
         "BossEscortType": "pmcbot",
         "BossName": "pmcbot",
@@ -103,7 +96,6 @@
         "TriggerName": "interactObject"
       },
       {
-        "BossChance": 35,
         "BossEscortAmount": "1,1,1,1,2,2,2,1,1,1,1,2,2,2,3",
         "BossEscortType": "pmcbot",
         "BossName": "pmcbot",
@@ -115,7 +107,6 @@
         "TriggerName": "interactObject"
       },
       {
-        "BossChance": 35,
         "BossEscortAmount": "1,1,1,1,2,2,2,1,1,1,1,2,2,2,3",
         "BossEscortType": "pmcbot",
         "BossName": "pmcbot",
@@ -127,7 +118,6 @@
         "TriggerName": "interactObject"
       },
       {
-        "BossChance": 35,
         "BossEscortAmount": "1,1,1,1,2,2,2,1,1,1,1,2,2,2,3",
         "BossEscortType": "pmcbot",
         "BossName": "pmcbot",
@@ -139,7 +129,6 @@
         "TriggerName": "interactObject"
       },
       {
-        "BossChance": 35,
         "BossEscortAmount": "1,1,1,1,2,2,2,1,1,1,1,2,2,2,3",
         "BossEscortType": "pmcbot",
         "BossName": "pmcbot",
@@ -151,7 +140,6 @@
         "TriggerName": "interactObject"
       },
       {
-        "BossChance": 35,
         "BossEscortAmount": "1,1,2,2,1,1,2,2,2,2,1,1,2,2,3",
         "BossEscortType": "pmcbot",
         "BossName": "pmcbot",
@@ -163,7 +151,6 @@
         "TriggerName": "interactObject"
       },
       {
-        "BossChance": 35,
         "BossEscortAmount": "1,1,2,2,1,1,2,2,2,2,1,1,2,2,3",
         "BossEscortType": "pmcbot",
         "BossName": "pmcbot",
@@ -175,7 +162,6 @@
         "TriggerName": "interactObject"
       },
       {
-        "BossChance": 35,
         "BossEscortAmount": "1,1,1,1,2,2,2,1,1,1,1,2,2,2,3",
         "BossEscortType": "pmcbot",
         "BossName": "pmcbot",
@@ -187,7 +173,6 @@
         "TriggerName": "interactObject"
       },
       {
-        "BossChance": 40,
         "BossEscortAmount": "1,1,1,1,2,2,2,1,1,1,1,2,2,2,3",
         "BossEscortType": "pmcbot",
         "BossName": "pmcbot",
@@ -199,7 +184,6 @@
         "TriggerName": "interactObject"
       },
       {
-        "BossChance": 45,
         "BossEscortAmount": "1,1,1,1,2,2,2,1,1,1,1,2,2,2,3",
         "BossEscortType": "pmcbot",
         "BossName": "pmcbot",

--- a/config/patterns/lighthouse_pmc.json
+++ b/config/patterns/lighthouse_pmc.json
@@ -10,8 +10,8 @@
             "MaxBotCount": 2
           }
         ],
-        "Time_min": 600,
-        "Time_max": 1800,
+        "Time_min": 400,
+        "Time_max": 1600,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": false,
         "BotZone": [
@@ -28,11 +28,11 @@
         "Bots": [
           {
             "BotType": "pmc",
-            "MaxBotCount": 3
+            "MaxBotCount": 2
           }
         ],
         "Time_min": 300,
-        "Time_max": 800,
+        "Time_max": 600,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": false,
         "BotZone": [
@@ -47,8 +47,8 @@
             "MaxBotCount": 2
           }
         ],
-        "Time_min": 1380,
-        "Time_max": 2400,
+        "Time_min": 500,
+        "Time_max": 2300,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": false,
         "BotZone": [

--- a/config/patterns/lighthouse_scav.json
+++ b/config/patterns/lighthouse_scav.json
@@ -8,40 +8,31 @@
           {
             "BotType": "assault",
             "MaxBotCount": 3
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 2
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 3
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 2
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 3
           }
         ],
-        "Time_min": 45,
-        "Time_max": 90,
+        "Time_min": 30,
+        "Time_max": 45,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": true,
-        "BotZone": null
+        "BotZone": [
+          "Zone_Chalet",
+          "Zone_Rocks",
+          "Zone_Bridge",
+          "Zone_LongRoad",
+          "Zone_DestroyedHouse",
+          "Zone_Village"
+        ]
       },
       {
-        "Name": "assaults",
+        "Name": "SCAVs",
         "Bots": [
           {
             "BotType": "assault",
             "MaxBotCount": 3
           }
         ],
-        "Time_min": 400,
-        "Time_max": 1420,
+        "Time_min": 300,
+        "Time_max": 900,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": false,
         "BotZone": [
@@ -50,12 +41,11 @@
           "Zone_Bridge",
           "Zone_LongRoad",
           "Zone_DestroyedHouse",
-          "Zone_Village",
-          "Zone_Containers"
+          "Zone_Village"
         ]
       },
       {
-        "Name": "assaults",
+        "Name": "more SCAVs",
         "Bots": [
           {
             "BotType": "assault",
@@ -69,6 +59,30 @@
         "BotZone": [
           "Zone_Chalet",
           "Zone_LongRoad"
+        ]
+      },
+      {
+        "Name": "WTP SCAVs",
+        "Bots": [
+          {
+            "BotType": "assault",
+            "MaxBotCount": 2
+          }
+        ],
+        "Time_min": 400,
+        "Time_max": 1800,
+        "RandomTimeSpawn": false,
+        "OnlySpawnOnce": false,
+        "BotZone": [
+          "Zone_TreatmentContainers",
+          "Zone_TreatmentRocks",
+          "Zone_Containers",
+          "Zone_Blockpost",
+          "Zone_Hellicopter",
+          "Zone_RoofRocks",
+          "Zone_RoofContainers",
+          "Zone_TreatmentBeach",
+          "Zone_RoofBeach"
         ]
       }
     ],

--- a/config/patterns/reserve_pmc.json
+++ b/config/patterns/reserve_pmc.json
@@ -10,8 +10,8 @@
             "MaxBotCount": 2
           }
         ],
-        "Time_min": 600,
-        "Time_max": 2000,
+        "Time_min": 400,
+        "Time_max": 1600,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": false,
         "BotZone": [
@@ -32,8 +32,8 @@
             "MaxBotCount": 2
           }
         ],
-        "Time_min": 800,
-        "Time_max": 1600,
+        "Time_min": 500,
+        "Time_max": 1300,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": false,
         "BotZone": [

--- a/config/patterns/reserve_raiders.json
+++ b/config/patterns/reserve_raiders.json
@@ -22,7 +22,6 @@
     ],
     "MapBosses": [
       {
-        "BossChance": 35,
         "BossEscortAmount": "2,2,2,2,3",
         "BossEscortType": "pmcbot",
         "BossName": "pmcbot",
@@ -32,7 +31,6 @@
         "Time": 1470
       },
       {
-        "BossChance": 40,
         "BossEscortAmount": "2,2,2,2,3",
         "BossEscortType": "pmcbot",
         "BossName": "pmcbot",
@@ -44,7 +42,6 @@
         "TriggerName": "interactObject"
       },
       {
-        "BossChance": 35,
         "BossEscortAmount": "2,2,2,2,3",
         "BossEscortType": "pmcbot",
         "BossName": "pmcbot",
@@ -56,7 +53,6 @@
         "TriggerName": "interactObject"
       },
       {
-        "BossChance": 25,
         "BossEscortAmount": "2,2,2,2,3",
         "BossEscortType": "pmcbot",
         "BossName": "pmcbot",

--- a/config/patterns/reserve_scav.json
+++ b/config/patterns/reserve_scav.json
@@ -8,29 +8,21 @@
           {
             "BotType": "assault",
             "MaxBotCount": 3
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 2
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 3
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 2
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 3
           }
         ],
-        "Time_min": 45,
-        "Time_max": 90,
+        "Time_min": 30,
+        "Time_max": 45,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": true,
-        "BotZone": null
+        "BotZone": [
+          "ZoneBarrack",
+          "ZoneRailStrorage",
+          "ZoneBunkerStorage",
+          "ZoneSubStorage",
+          "ZonePTOR2",
+          "ZonePTOR1",
+          "ZoneSubCommand"
+        ]
       },
       {
         "Name": "assaults",
@@ -40,8 +32,8 @@
             "MaxBotCount": 3
           }
         ],
-        "Time_min": 500,
-        "Time_max": 1620,
+        "Time_min": 300,
+        "Time_max": 900,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": false,
         "BotZone": [
@@ -62,8 +54,8 @@
             "MaxBotCount": 3
           }
         ],
-        "Time_min": 500,
-        "Time_max": 2000,
+        "Time_min": 220,
+        "Time_max": 800,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": false,
         "BotZone": [

--- a/config/patterns/shoreline_pmc.json
+++ b/config/patterns/shoreline_pmc.json
@@ -11,7 +11,7 @@
           }
         ],
         "Time_min": 600,
-        "Time_max": 2000,
+        "Time_max": 2200,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": false,
         "BotZone": [
@@ -41,8 +41,8 @@
             "MaxBotCount": 2
           }
         ],
-        "Time_min": 600,
-        "Time_max": 1600,
+        "Time_min": 300,
+        "Time_max": 900,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": false,
         "BotZone": [

--- a/config/patterns/shoreline_scav.json
+++ b/config/patterns/shoreline_scav.json
@@ -8,29 +8,30 @@
           {
             "BotType": "assault",
             "MaxBotCount": 3
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 3
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 3
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 3
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 3
           }
         ],
-        "Time_min": 45,
-        "Time_max": 90,
+        "Time_min": 30,
+        "Time_max": 45,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": true,
-        "BotZone": null
+        "BotZone": [
+          "ZonePowerStation",
+          "ZoneGreenHouses",
+          "ZoneSanatorium1",
+          "ZoneSanatorium2",
+          "ZoneBusStation",
+          "ZoneMeteoStation",
+          "ZoneForestGasStation",
+          "ZoneForestTruck",
+          "ZoneRailWays",
+          "ZoneStartVillage",
+          "ZoneIsland",
+          "ZonePort",
+          "ZoneBunker",
+          "ZonePassClose",
+          "ZonePassFar",
+          "ZoneTunnel"
+        ]
       },
       {
         "Name": "assaults",
@@ -40,8 +41,8 @@
             "MaxBotCount": 3
           }
         ],
-        "Time_min": 500,
-        "Time_max": 1800,
+        "Time_min": 300,
+        "Time_max": 1300,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": false,
         "BotZone": [
@@ -61,6 +62,24 @@
           "ZonePassClose",
           "ZonePassFar",
           "ZoneTunnel"
+        ]
+      },
+      {
+        "Name": "assaults",
+        "Bots": [
+          {
+            "BotType": "assault",
+            "MaxBotCount": 3
+          }
+        ],
+        "Time_min": 220,
+        "Time_max": 900,
+        "RandomTimeSpawn": false,
+        "OnlySpawnOnce": false,
+        "BotZone": [
+          "ZoneGreenHouses",
+          "ZoneSanatorium1",
+          "ZoneSanatorium2"
         ]
       }
     ],

--- a/config/patterns/streets_pmc.json
+++ b/config/patterns/streets_pmc.json
@@ -10,7 +10,7 @@
             "MaxBotCount": 2
           }
         ],
-        "Time_min": 600,
+        "Time_min": 450,
         "Time_max": 1800,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": false,
@@ -34,8 +34,8 @@
             "MaxBotCount": 2
           }
         ],
-        "Time_min": 500,
-        "Time_max": 1600,
+        "Time_min": 350,
+        "Time_max": 1400,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": false,
         "BotZone": [

--- a/config/patterns/streets_scav.json
+++ b/config/patterns/streets_scav.json
@@ -8,40 +8,36 @@
           {
             "BotType": "assault",
             "MaxBotCount": 3
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 3
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 3
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 3
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 3
           }
         ],
-        "Time_min": 45,
-        "Time_max": 90,
+        "Time_min": 30,
+        "Time_max": 45,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": true,
-        "BotZone": null
+        "BotZone": [
+          "ZoneHotel_2",
+          "ZoneHotel_1",
+          "ZoneConcordia_2",
+          "ZoneConcordia_1",
+          "ZoneConstruction",
+          "ZoneColumn",
+          "ZoneConcordiaParking",
+          "ZoneCarShowroom",
+          "ZoneCinema",
+          "ZoneSW01",
+          "ZoneFactory"
+        ]
       },
       {
         "Name": "assaults",
         "Bots": [
           {
             "BotType": "assault",
-            "MaxBotCount": 2
+            "MaxBotCount": 3
           }
         ],
-        "Time_min": 460,
-        "Time_max": 1620,
+        "Time_min": 300,
+        "Time_max": 900,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": false,
         "BotZone": [
@@ -53,7 +49,9 @@
           "ZoneColumn",
           "ZoneConcordiaParking",
           "ZoneCarShowroom",
-          "ZoneCinema"
+          "ZoneCinema",
+          "ZoneSW01",
+          "ZoneFactory"
         ]
       }
     ],

--- a/config/patterns/woods_pmc.json
+++ b/config/patterns/woods_pmc.json
@@ -10,7 +10,7 @@
             "MaxBotCount": 2
           }
         ],
-        "Time_min": 600,
+        "Time_min": 500,
         "Time_max": 1600,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": false,
@@ -34,7 +34,7 @@
             "MaxBotCount": 2
           }
         ],
-        "Time_min": 480,
+        "Time_min": 400,
         "Time_max": 1400,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": false,

--- a/config/patterns/woods_scav.json
+++ b/config/patterns/woods_scav.json
@@ -7,30 +7,24 @@
         "Bots": [
           {
             "BotType": "assault",
-            "MaxBotCount": 2
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 3
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 2
-          },
-          {
-            "BotType": "assault",
-            "MaxBotCount": 3
-          },
-          {
-            "BotType": "assault",
             "MaxBotCount": 3
           }
         ],
-        "Time_min": 45,
-        "Time_max": 90,
+        "Time_min": 30,
+        "Time_max": 45,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": true,
-        "BotZone": null
+        "BotZone": [
+          "ZoneScavBase2",
+          "ZoneMiniHouse",
+          "ZoneBigRocks",
+          "ZoneRedHouse",
+          "ZoneWoodCutter",
+          "ZoneRoad",
+          "ZoneHouse",
+          "ZoneClearVill",
+          "ZoneBrokenVill"
+        ]
       },
       {
         "Name": "assaults",
@@ -40,8 +34,8 @@
             "MaxBotCount": 3
           }
         ],
-        "Time_min": 400,
-        "Time_max": 1220,
+        "Time_min": 300,
+        "Time_max": 1000,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": false,
         "BotZone": [
@@ -65,7 +59,7 @@
           }
         ],
         "Time_min": 300,
-        "Time_max": 1000,
+        "Time_max": 700,
         "RandomTimeSpawn": false,
         "OnlySpawnOnce": false,
         "BotZone": [

--- a/src/ClassDef.ts
+++ b/src/ClassDef.ts
@@ -8,7 +8,16 @@ export interface SWAGConfig {
   aiAmount: "low" | "asonline" | "medium" | "high" | "horde";
   RandomWaveCount: number;
   BossWaveCount: number;
-  BossChance: number;
+  BossChance: {
+    gluhar: number,
+    killa: number,
+    tagilla: number,
+    zryachiy: number,
+    sanitar: number,
+    reshala: number,
+    shturman: number,
+    goons: number
+  }
   SkipOtherBossWavesIfBossWaveSelected: boolean;
   GlobalRandomWaveTimer: {
     WaveTimerMinSec: number;


### PR DESCRIPTION
3.5.5 update

New features and Improvements

NEW: Individual BossChance
Now you can define a "BossChance" for each individual named boss:
```json
    "BossChance": {
    "gluhar": 20,
    "killa": 20,
    "tagilla": 20,
    "zryachiy": 100,
    "sanitar": 20,
    "reshala": 20,
    "shturman": 20,
    "goons": 20
  }
```

NEW: RogueChance, RaiderChance
Additionally I've added the ability to define chance for Raiders and Rogues. Keep in mind that this applies to ALL Raider and Rogue spawns, including triggered spawns (such as D2 or Labs exfils, for example) and waves. Defaults are 80 each.

```json
  "RogueChance": 80,
  "RaiderChance": 80,
```

NEW: Define your own BossChance for any boss spawn (includes ALL bots)
You can now define your own BossChance, if desired, to any boss spawn. This includes named bosses, PMCs, Raiders and Rogues.

Example: add "BossChance": 50 to this PMC spawn in `customs_pmc.json`
```json
      {
        "Name": "sptbear",
        "BossName": "sptbear",
        "BossZone": ["ZoneBrige","ZoneWade"],
        "BossEscortType": "sptbear",
        "BossEscortAmount": "0,0,0,0,0,0,0,0,1",
        "BossChance": 50,
        "Time": -1,
        "Supports": null,
        "RandomTimeSpawn": false,
        "OnlySpawnOnce": true
      }
```
Useful for anyone who wants some more randomness and experimentation.

Map Changes & Tuning

All Maps
- slight increase to scavSpawnWeight: 75 > 80
- increased MaxBotPerZone: 6 > 8
- decreased default pmcSpawnWeight: 25 > 20
- increased default scavSpawnWeight: 75 > 80
- initial SCAV waves should now spawn a little earlier (<2 mins)
- initial SCAV waves will now spawn in ALL zones (previously random zones), so maps will fill a little faster early on

Customs
- increased max bot cap: 24 > 25
- increased spawns at Dorms and Customs (Big Red, Trailer Park area)

Factory
- shortened wave intervals

Interchange
- added additional waves in certain larger zones (Goshan, IDEA, etc.)

Labs
- all Raider spawns now use RaiderChance (in config.json)

Lighthouse
- all Rogue spawns now use RogueChance (in config.json)
- added SCAV waves to Water Treatment zones
- PMC waves now spawn earlier at Water Treatment zones

Reserve
- all Raider spawns now use RogueChance (in config.json)

Shoreline
- increased max bot cap: 26 > 28
- added SCAV waves to larger zones

Streets
- increased max bot cap: 24 > 25

Woods
- increased max bot cap: 26 > 27
- added SCAV waves in larger zones