### PR TITLE
Map name translator

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -87,7 +87,18 @@
 		"laboratory": 14,
 		"streets": 24
   },
-	"MaxBotPerZone": 7,
+	"MaxBotPerZone": {
+		"customs": 4,
+		"woods": 5,
+		"shoreline": 4,
+		"lighthouse": 5,
+		"factory": 15,
+		"interchange": 5,
+		"reserve": 4,
+		"laboratory": 3,
+		"streets": 5
+	},
+	
 	"UseDefaultSpawns": {
 		"Waves": false,
 		"Bosses": false,

--- a/src/ClassDef.ts
+++ b/src/ClassDef.ts
@@ -195,6 +195,10 @@ export const roleCase: object = {
   followerzryachiy: "followerZryachiy",
 };
 
+/** These lines could be removed when mergin
+It is the old implementation of the translation of the map names
+Replaced by mapNameTranslator
+
 export const reverseMapNames: object = {
   factory4_day: "factory",
   factory4_night: "factory_night",
@@ -207,7 +211,7 @@ export const reverseMapNames: object = {
   laboratory: "laboratory",
   tarkovstreets: "streets"
 };
-
+**/
 export const diffProper = {
   easy: "easy",
   asonline: "normal",

--- a/src/SWAG.ts
+++ b/src/SWAG.ts
@@ -72,7 +72,18 @@ const globalPatterns: GlobalPatterns = {};
 function mapNameTranslator(maplocation: string): string {
 	//dynamic map name translator. goes into server/database/locations/MAP/base.json and gets the "Name":[...] Entry of the map in lowerCase Style
 	let translatedMapName = locations[maplocation]?.base?.Name?.toLowerCase();
-	return translatedMapName;
+	
+	if(translatedMapName === "streets of tarkov") {
+		return "streets";
+	}
+	
+	if(translatedMapName === "reservebase") {
+		return "reserve";
+	}
+	
+	else {
+		return translatedMapName;
+	}
 }
 
 class SWAG implements IPreAkiLoadMod, IPostDBLoadMod {


### PR DESCRIPTION
implemented a small change in how the map name is translated. previously a fixed list has been used. now it uses the the base.json to get the names of all maps present in the location folder instead of having a fixed number of predefined map names.

the base idea for the function was the config.json value "MaxBotPerZone" which was defined as one fixed value for all the maps. now there is a value for each map and a fallback that is being used for unknown maps or even new maps

this logic is now being used for all spawn/weight chances of bots and scavs, since they use the same way to to read values from the config.json file